### PR TITLE
Define Errors as a struct that encapsulates the error slice.

### DIFF
--- a/action_handler.go
+++ b/action_handler.go
@@ -112,7 +112,7 @@ func validate(message interface{}) error {
 		return nil
 	} else if err := validator.Validate(); err == nil {
 		return nil
-	} else if errors, ok := err.(Errors); ok && len(errors) == 0 {
+	} else if errors, ok := err.(*Errors); ok && len(errors.errors) == 0 {
 		return nil
 	} else {
 		return err
@@ -136,7 +136,7 @@ func (this *ActionHandler) handle(message interface{}, response http.ResponseWri
 func writeErrorResponse(response http.ResponseWriter, request *http.Request, err error, code int) {
 	var result Renderer
 
-	if _, ok := err.(Errors); ok {
+	if _, ok := err.(*Errors); ok {
 		result = &JSONResult{StatusCode: code, Content: err}
 	} else if _, ok := err.(*DiagnosticError); ok {
 		result = &DiagnosticResult{StatusCode: code, Message: err.Error()}

--- a/app_test.go
+++ b/app_test.go
@@ -72,8 +72,8 @@ func (this *BindingInputModel) Bind(request *http.Request) error {
 type BindingFailsInputModel struct{}
 
 func (this *BindingFailsInputModel) Bind(request *http.Request) error {
-	var errors Errors
-	errors = errors.Append(NewBindingValidationError("BindingFailsInputModel"))
+	var errors *Errors = new(Errors)
+	errors.Append(NewBindingValidationError("BindingFailsInputModel"))
 	return errors
 }
 
@@ -120,8 +120,8 @@ func (this *ValidatingInputModel) Validate() error {
 type ValidatingFailsInputModel struct{}
 
 func (this *ValidatingFailsInputModel) Validate() error {
-	var errors Errors
-	errors = errors.Append(NewBindingValidationError("ValidatingFailsInputModel"))
+	var errors *Errors = new(Errors)
+	errors.Append(NewBindingValidationError("ValidatingFailsInputModel"))
 	return errors
 }
 
@@ -131,7 +131,7 @@ type ValidatingEmptyErrorsInputModel struct{ Content string }
 
 func (this *ValidatingEmptyErrorsInputModel) Validate() error {
 	this.Content = "ValidatingEmptyErrorsInputModel"
-	var errors Errors
+	var errors *Errors = new(Errors)
 	return errors
 }
 

--- a/errors.go
+++ b/errors.go
@@ -2,31 +2,30 @@ package detour
 
 import "encoding/json"
 
-type Errors []error
+type Errors struct {
+	errors []error
+}
 
-func (this Errors) AppendIf(err error, condition bool) Errors {
+func (this *Errors) AppendIf(err error, condition bool) {
 	if condition {
-		return this.Append(err)
-	} else {
-		return this
+		this.Append(err)
 	}
 }
 
-func (this Errors) Append(err error) Errors {
+func (this *Errors) Append(err error) {
 	if err != nil {
-		this = append(this, err)
+		this.errors = append(this.errors, err)
 	}
-	return this
 }
 
-func (this Errors) Error() string {
+func (this *Errors) Error() string {
 	raw, _ := this.MarshalJSON()
 	return string(raw)
 }
 
-func (this Errors) MarshalJSON() ([]byte, error) {
+func (this *Errors) MarshalJSON() ([]byte, error) {
 	filtered := []error{}
-	for _, err := range this {
+	for _, err := range this.errors {
 		if err != nil {
 			filtered = append(filtered, err)
 		}

--- a/errors_test.go
+++ b/errors_test.go
@@ -15,28 +15,32 @@ func TestErrorFixture(t *testing.T) {
 type ErrorFixture struct {
 	*gunit.Fixture
 
-	problems Errors
+	problems *Errors
+}
+
+func (this *ErrorFixture) Setup() {
+	this.problems = new(Errors)
 }
 
 func (this *ErrorFixture) TestErrorAppendIf() {
-	this.problems = this.problems.AppendIf(errors.New(""), true)
-	this.problems = this.problems.AppendIf(errors.New(""), false)
-	this.problems = this.problems.AppendIf(errors.New(""), true)
-	this.problems = this.problems.AppendIf(errors.New(""), false)
-	this.So(len(this.problems), should.Equal, 2)
+	this.problems.AppendIf(errors.New(""), true)
+	this.problems.AppendIf(errors.New(""), false)
+	this.problems.AppendIf(errors.New(""), true)
+	this.problems.AppendIf(errors.New(""), false)
+	this.So(len(this.problems.errors), should.Equal, 2)
 }
 
 func (this *ErrorFixture) TestErrorAggregation() {
-	this.So(this.problems, should.BeNil)
+	this.So(this.problems.errors, should.BeNil)
 
-	this.problems = this.problems.Append(errors.New("hi"))
-	this.problems = this.problems.Append(errors.New("bye"))
+	this.problems.Append(errors.New("hi"))
+	this.problems.Append(errors.New("bye"))
 
-	this.So(len(this.problems), should.Equal, 2)
+	this.So(len(this.problems.errors), should.Equal, 2)
 }
 
 func (this *ErrorFixture) TestErrorSerialization() {
-	this.problems = this.problems.Append(SimpleInputError("Hello", "World"))
+	this.problems.Append(SimpleInputError("Hello", "World"))
 
 	this.So(this.problems.Error(), should.Equal, `[{"fields":["World"],"message":"Hello"}]`)
 }

--- a/result.go
+++ b/result.go
@@ -105,11 +105,11 @@ func (this *JSONPResult) Render(response http.ResponseWriter, request *http.Requ
 func (this *ValidationResult) Render(response http.ResponseWriter, request *http.Request) {
 	writeContentType(response, jsonContentType)
 
-	var failures Errors
-	failures = failures.Append(this.Failure1)
-	failures = failures.Append(this.Failure2)
-	failures = failures.Append(this.Failure3)
-	failures = failures.Append(this.Failure4)
+	var failures *Errors = new(Errors)
+	failures.Append(this.Failure1)
+	failures.Append(this.Failure2)
+	failures.Append(this.Failure3)
+	failures.Append(this.Failure4)
 
 	serializeAndWrite(response, http.StatusUnprocessableEntity, failures)
 }
@@ -117,11 +117,11 @@ func (this *ValidationResult) Render(response http.ResponseWriter, request *http
 func (this *ErrorResult) Render(response http.ResponseWriter, request *http.Request) {
 	writeContentType(response, jsonContentType)
 
-	var failures Errors
-	failures = failures.Append(this.Error1)
-	failures = failures.Append(this.Error2)
-	failures = failures.Append(this.Error3)
-	failures = failures.Append(this.Error4)
+	var failures *Errors = new(Errors)
+	failures.Append(this.Error1)
+	failures.Append(this.Error2)
+	failures.Append(this.Error3)
+	failures.Append(this.Error4)
 
 	serializeAndWrite(response, this.StatusCode, failures)
 }
@@ -180,7 +180,8 @@ func writeContent(response http.ResponseWriter, statusCode int, content []byte) 
 }
 func writeError(response http.ResponseWriter) {
 	response.WriteHeader(http.StatusInternalServerError)
-	errContent := make(Errors, 0).Append(SimpleInputError("Marshal failure", "HTTP Response"))
+	errContent := new(Errors)
+	errContent.Append(SimpleInputError("Marshal failure", "HTTP Response"))
 	content, _ := json.Marshal(errContent)
 	response.Write(content)
 }


### PR DESCRIPTION
Defining Errors as []error was a mistake. It made it too easy to forget
to reassign the result of Append and AppendIf.