### PR TITLE
JSONResults now have the option to render indented JSON via Indent field

### DIFF
--- a/action_handler_test.go
+++ b/action_handler_test.go
@@ -59,7 +59,7 @@ func (this *ModelBinderFixture) TestBindsModelAndHandlesError__HTTP400_JSONRespo
 	binder.ServeHTTP(this.response, this.request)
 	this.So(this.response.Code, should.Equal, 400)
 	this.So(this.response.HeaderMap.Get(contentTypeHeader), should.Equal, jsonContentType)
-	this.So(this.response.Body.String(), should.Equal, `[{"Problem":"BindingFailsInputModel"}]`)
+	this.So(this.response.Body.String(), should.EqualTrimSpace, `[{"Problem":"BindingFailsInputModel"}]`)
 }
 
 func (this *ModelBinderFixture) TestBindsModelAndHandlesNilErrors() {
@@ -98,7 +98,7 @@ func (this *ModelBinderFixture) TestValidatesModelAndHandlesError__HTTP422() {
 	binder.ServeHTTP(this.response, this.request)
 	this.So(this.response.Code, should.Equal, 422)
 	this.So(this.response.HeaderMap.Get(contentTypeHeader), should.Equal, jsonContentType)
-	this.So(this.response.Body.String(), should.Equal, `[{"Problem":"ValidatingFailsInputModel"}]`)
+	this.So(this.response.Body.String(), should.EqualTrimSpace, `[{"Problem":"ValidatingFailsInputModel"}]`)
 }
 
 func (this *ModelBinderFixture) TestValidatesModelEmptyValidationErrors__HTTP200() {

--- a/render.go
+++ b/render.go
@@ -16,6 +16,12 @@ func firstNonBlank(values ...string) string {
 	return ""
 }
 
+func writeJSONResponse(response http.ResponseWriter, statusCode int, content interface{}, contentType, indent string) {
+	writeContentType(response, contentType)
+	serialized, err := serializeJSON(content, indent)
+	writeResponse(response, statusCode, serialized, err)
+}
+
 func writeContentTypeAndStatusCode(response http.ResponseWriter, statusCode int, contentType string) {
 	writeContentType(response, contentType)
 	response.WriteHeader(orOK(statusCode))
@@ -26,6 +32,7 @@ func writeContentType(response http.ResponseWriter, contentType string) {
 		response.Header().Set(contentTypeHeader, contentType) // doesn't get written unless status code is written last!
 	}
 }
+
 func serializeJSON(content interface{}, indent string) ([]byte, error) {
 	writer := new(bytes.Buffer)
 	encoder := json.NewEncoder(writer)

--- a/render.go
+++ b/render.go
@@ -6,16 +6,6 @@ import (
 	"net/http"
 )
 
-func firstNonBlank(values ...string) string {
-	for _, value := range values {
-		if len(value) > 0 {
-			return value
-		}
-	}
-
-	return ""
-}
-
 func writeJSONResponse(response http.ResponseWriter, statusCode int, content interface{}, contentType, indent string) {
 	writeContentType(response, contentType)
 	serialized, err := serializeJSON(content, indent)
@@ -69,6 +59,16 @@ func orOK(statusCode int) int {
 		return http.StatusOK
 	}
 	return statusCode
+}
+
+func firstNonBlank(values ...string) string {
+	for _, value := range values {
+		if len(value) > 0 {
+			return value
+		}
+	}
+
+	return ""
 }
 
 const (

--- a/render_error.go
+++ b/render_error.go
@@ -19,5 +19,6 @@ func (this ErrorResult) Render(response http.ResponseWriter, request *http.Reque
 	failures = failures.Append(this.Error3)
 	failures = failures.Append(this.Error4)
 
-	serializeAndWrite(response, this.StatusCode, failures)
+	content, err := serializeJSON(failures, "")
+	writeResponse(response, this.StatusCode, content, err)
 }

--- a/render_error.go
+++ b/render_error.go
@@ -11,14 +11,11 @@ type ErrorResult struct {
 }
 
 func (this ErrorResult) Render(response http.ResponseWriter, request *http.Request) {
-	writeContentType(response, jsonContentType)
-
 	var failures Errors
 	failures = failures.Append(this.Error1)
 	failures = failures.Append(this.Error2)
 	failures = failures.Append(this.Error3)
 	failures = failures.Append(this.Error4)
 
-	content, err := serializeJSON(failures, "")
-	writeResponse(response, this.StatusCode, content, err)
+	writeJSONResponse(response, this.StatusCode, failures, jsonContentType, "")
 }

--- a/render_json.go
+++ b/render_json.go
@@ -6,23 +6,11 @@ type JSONResult struct {
 	StatusCode  int
 	ContentType string
 	Content     interface{}
+	Indent      string
 }
 
 func (this JSONResult) Render(response http.ResponseWriter, request *http.Request) {
-	contentType := firstNonBlank(this.ContentType, jsonContentType)
-	writeContentType(response, contentType)
-	serializeAndWrite(response, this.StatusCode, this.Content)
-}
-
-type JSONPResult struct {
-	StatusCode  int
-	ContentType string
-	Content     interface{}
-}
-
-func (this JSONPResult) Render(response http.ResponseWriter, request *http.Request) {
-	contentType := firstNonBlank(this.ContentType, jsonContentType)
-	writeContentType(response, contentType)
-	callbackLabel := request.URL.Query().Get("callback") // We don't call request.ParseForm in every case so using the URL.Query() is safer.
-	serializeAndWriteJSONP(response, this.StatusCode, this.Content, callbackLabel)
+	writeContentType(response, firstNonBlank(this.ContentType, jsonContentType))
+	content, err := serializeJSON(this.Content, this.Indent)
+	writeResponse(response, this.StatusCode, content, err)
 }

--- a/render_json.go
+++ b/render_json.go
@@ -10,7 +10,9 @@ type JSONResult struct {
 }
 
 func (this JSONResult) Render(response http.ResponseWriter, request *http.Request) {
-	writeContentType(response, firstNonBlank(this.ContentType, jsonContentType))
-	content, err := serializeJSON(this.Content, this.Indent)
-	writeResponse(response, this.StatusCode, content, err)
+	writeJSONResponse(response,
+		this.StatusCode,
+		this.Content,
+		firstNonBlank(this.ContentType, jsonContentType),
+		this.Indent)
 }

--- a/render_json_test.go
+++ b/render_json_test.go
@@ -14,6 +14,21 @@ func (this *ResultFixture) TestJSONResult() {
 	this.assertContent(`{"key":"value"}`)
 	this.assertHasHeader(contentTypeHeader, jsonContentType)
 }
+func (this *ResultFixture) TestJSONResultIndented() {
+	result := JSONResult{
+		StatusCode: 123,
+		Content:    map[string]string{"key": "value"},
+		Indent:     "  ",
+	}
+
+	this.render(result)
+
+	this.assertStatusCode(123)
+	this.assertContent(`{
+  "key": "value"
+}`)
+	this.assertHasHeader(contentTypeHeader, jsonContentType)
+}
 func (this *ResultFixture) TestJSONResult_WithCustomContentType() {
 	result := JSONResult{
 		StatusCode:  123,
@@ -47,69 +62,4 @@ func (this *ResultFixture) TestJSONResult_StatusCodeDefaultsTo200() {
 	this.render(result)
 
 	this.assertStatusCode(http.StatusOK)
-}
-
-func (this *ResultFixture) TestJSONPResult() {
-	this.setRequestURLCallback("maybe")
-	result := JSONPResult{
-		StatusCode: 123,
-		Content:    map[string]string{"key": "value"},
-	}
-
-	this.render(result)
-
-	this.assertStatusCode(123)
-	this.assertContent(`maybe({"key":"value"})`)
-	this.assertHasHeader(contentTypeHeader, jsonContentType)
-}
-func (this *ResultFixture) TestJSONPResult_WithCustomContentType() {
-	this.setRequestURLCallback("maybe")
-	result := JSONPResult{
-		StatusCode:  123,
-		ContentType: "application/custom-json",
-		Content:     map[string]string{"key": "value"},
-	}
-
-	this.render(result)
-
-	this.assertStatusCode(123)
-	this.assertContent(`maybe({"key":"value"})`)
-	this.assertHasHeader(contentTypeHeader, "application/custom-json")
-}
-func (this *ResultFixture) TestJSONPResult_SerializationFailure_HTTP500WithErrorMessage() {
-	this.setRequestURLCallback("maybe")
-	result := JSONPResult{
-		StatusCode: 123,
-		Content:    new(BadJSON),
-	}
-
-	this.render(result)
-
-	this.assertStatusCode(500)
-	this.assertHasHeader(contentTypeHeader, jsonContentType)
-	this.assertContent(`[{"fields":["HTTP Response"],"message":"Marshal failure"}]`)
-}
-func (this *ResultFixture) TestJSONPResult_StatusCodeDefaultsTo200() {
-	this.setRequestURLCallback("maybe")
-	result := JSONPResult{
-		StatusCode: 0,
-		Content:    42,
-	}
-
-	this.render(result)
-
-	this.assertStatusCode(http.StatusOK)
-}
-func (this *ResultFixture) TestJSONPResult_NoCallback_SerializesAsPlainOldJSON() {
-	this.setRequestURLCallback("")
-	result := JSONPResult{
-		StatusCode: 123,
-		Content:    map[string]string{"key": "value"},
-	}
-
-	this.render(result)
-
-	this.assertStatusCode(123)
-	this.assertContent(`{"key":"value"}`)
-	this.assertHasHeader(contentTypeHeader, jsonContentType)
 }

--- a/render_jsonp.go
+++ b/render_jsonp.go
@@ -1,0 +1,34 @@
+package detour
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+type JSONPResult struct {
+	StatusCode  int
+	ContentType string
+	Content     interface{}
+	Indent      string
+}
+
+func (this JSONPResult) Render(response http.ResponseWriter, request *http.Request) {
+	writeContentType(response, firstNonBlank(this.ContentType, jsonContentType))
+	content, err := serializeJSON(this.Content, this.Indent)
+	content = wrapJSONP(content, callbackLabel(request))
+	writeResponse(response, this.StatusCode, content, err)
+}
+
+func wrapJSONP(content []byte, label string) []byte {
+	serialized := strings.TrimSpace(string(content))
+	if len(label) > 0 {
+		serialized = fmt.Sprintf("%s(%s)", label, serialized)
+	}
+	return []byte(serialized)
+}
+
+func callbackLabel(request *http.Request) string {
+	// We don't call request.ParseForm in every case so using the URL.Query() is safer.
+	return request.URL.Query().Get("callback")
+}

--- a/render_jsonp_test.go
+++ b/render_jsonp_test.go
@@ -1,0 +1,84 @@
+package detour
+
+import "net/http"
+
+func (this *ResultFixture) TestJSONPResult() {
+	this.setRequestURLCallback("maybe")
+	result := JSONPResult{
+		StatusCode: 123,
+		Content:    map[string]string{"key": "value"},
+	}
+
+	this.render(result)
+
+	this.assertStatusCode(123)
+	this.assertContent(`maybe({"key":"value"})`)
+	this.assertHasHeader(contentTypeHeader, jsonContentType)
+}
+func (this *ResultFixture) TestJSONPResultIndented() {
+	this.setRequestURLCallback("maybe")
+	result := JSONPResult{
+		StatusCode: 123,
+		Content:    map[string]string{"key": "value"},
+		Indent:     "  ",
+	}
+
+	this.render(result)
+
+	this.assertStatusCode(123)
+	this.assertContent(`maybe({
+  "key": "value"
+})`)
+	this.assertHasHeader(contentTypeHeader, jsonContentType)
+}
+func (this *ResultFixture) TestJSONPResult_WithCustomContentType() {
+	this.setRequestURLCallback("maybe")
+	result := JSONPResult{
+		StatusCode:  123,
+		ContentType: "application/custom-json",
+		Content:     map[string]string{"key": "value"},
+	}
+
+	this.render(result)
+
+	this.assertStatusCode(123)
+	this.assertContent(`maybe({"key":"value"})`)
+	this.assertHasHeader(contentTypeHeader, "application/custom-json")
+}
+func (this *ResultFixture) TestJSONPResult_SerializationFailure_HTTP500WithErrorMessage() {
+	this.setRequestURLCallback("maybe")
+	result := JSONPResult{
+		StatusCode: 123,
+		Content:    new(BadJSON),
+	}
+
+	this.render(result)
+
+	this.assertStatusCode(500)
+	this.assertHasHeader(contentTypeHeader, jsonContentType)
+	this.assertContent(`[{"fields":["HTTP Response"],"message":"Marshal failure"}]`)
+}
+func (this *ResultFixture) TestJSONPResult_StatusCodeDefaultsTo200() {
+	this.setRequestURLCallback("maybe")
+	result := JSONPResult{
+		StatusCode: 0,
+		Content:    42,
+	}
+
+	this.render(result)
+
+	this.assertStatusCode(http.StatusOK)
+}
+func (this *ResultFixture) TestJSONPResult_NoCallback_SerializesAsPlainOldJSON() {
+	this.setRequestURLCallback("")
+	result := JSONPResult{
+		StatusCode: 123,
+		Content:    map[string]string{"key": "value"},
+	}
+
+	this.render(result)
+
+	this.assertStatusCode(123)
+	this.assertContent(`{"key":"value"}`)
+	this.assertHasHeader(contentTypeHeader, jsonContentType)
+}

--- a/render_validation.go
+++ b/render_validation.go
@@ -10,14 +10,11 @@ type ValidationResult struct {
 }
 
 func (this ValidationResult) Render(response http.ResponseWriter, request *http.Request) {
-	writeContentType(response, jsonContentType)
-
 	var failures Errors
 	failures = failures.Append(this.Failure1)
 	failures = failures.Append(this.Failure2)
 	failures = failures.Append(this.Failure3)
 	failures = failures.Append(this.Failure4)
 
-	content, err := serializeJSON(failures, "")
-	writeResponse(response, http.StatusUnprocessableEntity, content, err)
+	writeJSONResponse(response, http.StatusUnprocessableEntity, failures, jsonContentType, "")
 }

--- a/render_validation.go
+++ b/render_validation.go
@@ -18,5 +18,6 @@ func (this ValidationResult) Render(response http.ResponseWriter, request *http.
 	failures = failures.Append(this.Failure3)
 	failures = failures.Append(this.Failure4)
 
-	serializeAndWrite(response, http.StatusUnprocessableEntity, failures)
+	content, err := serializeJSON(failures, "")
+	writeResponse(response, http.StatusUnprocessableEntity, content, err)
 }


### PR DESCRIPTION
This led to changes in the functions that serialize JSON:

- We now use a JSON encoder which facilitates indenting
- A few assertions were made to allow for trailing whitespace (encoder)
- Decoupled JSONp from JSON serialization because it's an exception.